### PR TITLE
Remove headset activation from device controller

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -40,8 +40,6 @@ interface FakeXRDeviceController {
   // requestAnimationFrame() callbacks.
   void setXRPresentationFrameData(Float32Array poseModelMatrix, Array<FakeXRViewInit> views);
 
-  // Simulates the user activating the headset.
-  void simulateHeadsetActivation();
   // Simulates the user activating the reset pose on a device.
   void simulateResetPose();
 


### PR DESCRIPTION
Headset activation is not finalized in the WebXR spec, so we'll remove for now until there is more clarity on the API. 