### PR TITLE
Update test API to match current spec model

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -32,10 +32,10 @@ dictionary FakeXRDeviceInit {
     required boolean supportsImmersive;
     required Array<FakeXRViewInit> views;
 
-    boolean supportsBounded = true;
-    boolean supportsUnbounded = true;
+    boolean supportsUnbounded = false;
     // Whether the space supports tracking in inline sessions
     boolean supportsTrackingInInline = true;
+    // The bounds coordinates. If null, bounded reference spaces are not supported.
     Array<FakeXRBoundsPoint>? boundsCoodinates = null;
     // Eye level used for calculating floor-level spaces
     float eyeLevel = 1.5;

--- a/explainer.md
+++ b/explainer.md
@@ -6,13 +6,14 @@ interface with a WebDriver API while others may use HTTP or IPC mechanisms to co
 fake backend.
 
 ```WebIDL
+partial interface XR {
+    [SameObject] readonly attribute XRTest test;
+};
+
 interface XRTest {
   // Simulates connecting a device to the system.
   // Used to instantiate a fake device for use in tests.
-  Promise<FakeXRDeviceController> simulateDeviceConnection(FakeXRDeviceInit);
-
-  // Simulates a device being disconnected from the system.
-  Promise<void> simulateDeviceDisconnection(XRDevice);
+  Promise<FakeXRDevice> simulateDeviceConnection(FakeXRDeviceInit);
 
   // Simulates a user activation (aka user gesture) for the current scope.
   // The activation is only guaranteed to be valid in the provided function and only applies to WebXR
@@ -21,68 +22,100 @@ interface XRTest {
 };
 ```
 
-The promise returned from simulateDeviceConnection resolves with a FakeXRDeviceController, which can be used 
-to control the fake XRDevice that has been created in the background. The fake device may be returned by 
-navigator.xr.requestDevice, depending on how many devices have been created and how the browser decides to hand 
+The promise returned from simulateDeviceConnection resolves with a FakeXRDevice, which can be used 
+to control the fake XRDevice that has been created in the background. The fake device may be used in a session returned by 
+navigator.xr.requestSession(), depending on how many devices have been created and how the browser decides to hand 
 them out.
 
 ```WebIDL
 dictionary FakeXRDeviceInit {
-	// TODO: Subject to change to match spec changes.
-	required boolean supportsImmersive;
+    required boolean supportsImmersive;
+    required Array<FakeXRViewInit> views;
+
+    boolean supportsBounded = true;
+    boolean supportsUnbounded = true;
+    // Whether the space supports tracking in inline sessions
+    boolean supportsTrackingInInline = true;
+    Array<FakeXRBoundsPoint>? boundsCoodinates = null;
+    // Eye level used for calculating floor-level spaces
+    float eyeLevel = 1.5;
 }
 
-interface FakeXRDeviceController {
-	// Creates and attaches a XRFrameOfReference of the type specified to the device. 
-  void setFrameOfReference(XRFrameOfReferenceType,  FakeXRFrameOfReferenceInit);
-
+interface FakeXRDevice {
   // Sets the values to be used for subsequent
   // requestAnimationFrame() callbacks.
-  void setXRPresentationFrameData(Float32Array poseModelMatrix, Array<FakeXRViewInit> views);
+  void setViews(Array<FakeXRViewInit> views);
 
-  // Simulates the user activating the reset pose on a device.
-  void simulateResetPose();
+  // behaves as if device was disconnected
+  void disconnect();
 
-  // Simulates the platform ending the sessions.
-  void simulateForcedEndSessions();
+  // Sets the origin of the viewer
+  void setViewerOrigin(FakeXRRigidTransformInit origin, boolean emulatedPosition = false);
 
   // Simulates devices focusing and blurring sessions.
-  void simulateBlurSession(XRSession);
-  void simulateFocusSession(XRSession);
-  
-  Promise<FakeXRInputSourceController>  
-      simulateInputSourceConnection(FakeXRInputSourceInit);
-}
+  void simulateVisibilityChange(XRVisibilityState);
 
-interface FakeXRViewInit {
-  required XREye eye;
-  required Float32Array projectionMatrix;
-  required Float32Array viewMatrix;
+  void setBoundsGeometry(Array<FakeXRBoundsPoint> boundsCoodinates);
+  // Sets eye level used for calculating floor-level spaces
+  void setEyeLevel(float eyeLevel);
+
+  
+  Promise<FakeXRInputController>  
+      simulateInputSourceConnection(FakeXRInputSourceInit);
 };
 
-dictionary FakeXRFrameOfReferenceInit {
-  // The transform is an offset from the default world coordinates. 
-  // TODO: As the value can change on a per frame basis, this should be setable in 
-  // setXRPresentationFrameData.
-  Float32Array transform;
-  //TODO: Need to have a way to set this to trigger an onBoundsChangedEvent.
-  Array<FakeXRBoundsPoint> boundsCoodinates;
-}
+// https://immersive-web.github.io/webxr/#dom-xrwebgllayer-getviewport
+dictionary FakeXRViewInit {
+  required XREye eye;
+  // https://immersive-web.github.io/webxr/#view-projection-matrix
+  required Float32Array projectionMatrix;
+  // https://immersive-web.github.io/webxr/#view-offset
+  required Float32Array viewOffset;
+  // https://immersive-web.github.io/webxr/#dom-xrwebgllayer-getviewport
+  required FakeXRViewportInit viewport;
+};
+
+// https://immersive-web.github.io/webxr/#xrviewport
+dictionary FakeXRViewportInit {
+    required long x;
+    required long y;
+    required long width;
+    required long height;
+};
 
 dictionary FakeXRBoundsPoint {
   double x; double z;
-}
+};
+
+// When used as a native origin, it is in the reference space
+// where the viewer's native origin is identity at initialization
+dictionary FakeXRRigidTransformInit {
+  required Float32Array position;
+  required Float32Array orientation;
+};
 
 interface FakeXRInputSourceInit {
   XRHandedness handedness;
-  XRPointerOrigin pointerOrigin;
+  XRTargetRayMode targetRayMode;
 };
 
-interface FakeXRInputSourceController {
-  void setPose(
+interface FakeXRInputController {
+  void setOrigins(
     boolean emulatedPosition, 
-    Float32Array pointerMatrix, 
-    Float32Array? gripMatrix);
+    FakeXRRigidTransformInit pointerOrigin, 
+    FakeXRRigidTransformInit? gripOrigin);
+
+  // Temporarily disconnect the input device
+  void disconnect();
+
+  // Reconnect a disconnected input device
+  void reconnect();
+
+  // Start a selection for the current frame with the given button index
+  void startSelection(long? buttonIndex = null);
+
+  // End selection for the current frame with the given button index
+  void endSelection(long? buttonIndex = null);
 };
 ```
 

--- a/explainer.md
+++ b/explainer.md
@@ -19,6 +19,9 @@ interface XRTest {
   // The activation is only guaranteed to be valid in the provided function and only applies to WebXR
   // Device API methods.
   void simulateUserActivation(Function);
+
+  // Disconnect all fake devices
+  Promise<void> disconnectAllDevices();
 };
 ```
 
@@ -47,7 +50,7 @@ interface FakeXRDevice {
   void setViews(Array<FakeXRViewInit> views);
 
   // behaves as if device was disconnected
-  void disconnect();
+  Promise<void> disconnect();
 
   // Sets the origin of the viewer
   void setViewerOrigin(FakeXRRigidTransformInit origin, boolean emulatedPosition = false);
@@ -106,10 +109,10 @@ interface FakeXRInputController {
     FakeXRRigidTransformInit? gripOrigin);
 
   // Temporarily disconnect the input device
-  void disconnect();
+  Promise<void> disconnect();
 
   // Reconnect a disconnected input device
-  void reconnect();
+  Promise<void> reconnect();
 
   // Start a selection for the current frame with the given button index
   void startSelection(long? buttonIndex = null);

--- a/explainer.md
+++ b/explainer.md
@@ -92,6 +92,8 @@ dictionary FakeXRBoundsPoint {
 
 // When used as a native origin, it is in the reference space
 // where the viewer's native origin is identity at initialization
+//
+// https://immersive-web.github.io/webxr/#xrrigidtransform
 dictionary FakeXRRigidTransformInit {
   required Float32Array position;
   required Float32Array orientation;

--- a/explainer.md
+++ b/explainer.md
@@ -42,6 +42,7 @@ dictionary FakeXRDeviceInit {
     Array<FakeXRBoundsPoint>? boundsCoodinates = null;
     // Eye level used for calculating floor-level spaces
     float eyeLevel = 1.5;
+    FakeXRRigidTransformInit? viewerOrigin = null;
 }
 
 interface FakeXRDevice {
@@ -102,6 +103,10 @@ dictionary FakeXRRigidTransformInit {
 interface FakeXRInputSourceInit {
   XRHandedness handedness;
   XRTargetRayMode targetRayMode;
+  // was the primary action pressed when this was connected?
+  bool selectionStarted = false;
+  FakeXRRigidTransformInit? pointerOrigin = null;
+  FakeXRRigidTransformInit? gripOrigin = null;
 };
 
 interface FakeXRInputController {
@@ -117,10 +122,10 @@ interface FakeXRInputController {
   Promise<void> reconnect();
 
   // Start a selection for the current frame with the given button index
-  void startSelection(long? buttonIndex = null);
+  void startSelection();
 
   // End selection for the current frame with the given button index
-  void endSelection(long? buttonIndex = null);
+  void endSelection();
 };
 ```
 


### PR DESCRIPTION
I don't want to land this without coordinating an update in WPT (and getting other test API users to implement this), however I'm opening this pull request now so we can start discussing what this API should be like.

Since the creation of this API the webxr spec has changed quite a bit: It's moved off of explicitly providing view matrices, and now talks in terms of native origins. I think it would be useful for the mock API to mock the fundamental pieces (native origins, view offsets), as opposed to simply mocking the data that WebXR is supposed to return. This way we can write good tests that ensure that the matrix math is occurring correctly in the implementation.

<s>I'm going to start implementing this in Servo and writing (non-upstream) tests, and hopefully once everyone is on the same page about this we can merge it and update WPT as well as any browser running these tests.</s>

**Update (June 12)**: We discussed this a bit at the face-to-face, and the general feeling was that we're okay with drastic changes to the API (my initial attempt was quite conservative). I've updated the pull request with a new proposal that changes how a bunch of things work. This is a strawman proposal, major changes are okay/encouraged!