### PR TITLE
Make XRRigidTransform have required fields again

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -43,7 +43,8 @@ dictionary FakeXRDeviceInit {
     sequence<FakeXRBoundsPoint> boundsCoodinates;
     // Eye level used for calculating floor-level spaces
     float eyeLevel = 1.5;
-    // {} defaults to an identity transform
+    // native origin of the viewer
+    // defaults to identity
     FakeXRRigidTransformInit viewerOrigin;
 };
 
@@ -78,8 +79,7 @@ dictionary FakeXRViewInit {
   // https://immersive-web.github.io/webxr/#dom-xrwebgllayer-getviewport
   required FakeXRViewportInit viewport;
   // https://immersive-web.github.io/webxr/#view-offset
-  // {} defaults to an identity transform
-  FakeXRRigidTransformInit viewOffset;
+  required FakeXRRigidTransformInit viewOffset;
 };
 
 // https://immersive-web.github.io/webxr/#xrviewport
@@ -100,19 +100,17 @@ dictionary FakeXRBoundsPoint {
 // https://immersive-web.github.io/webxr/#xrrigidtransform
 dictionary FakeXRRigidTransformInit {
   // must have three elements
-  sequence<float> position;
+  required sequence<float> position;
   // must have four elements
-  sequence<float> orientation;
+  required sequence<float> orientation;
 };
 
 interface FakeXRInputSourceInit {
-  XRHandedness handedness;
-  XRTargetRayMode targetRayMode;
+  required XRHandedness handedness;
+  required XRTargetRayMode targetRayMode;
+  required FakeXRRigidTransformInit pointerOrigin;
   // was the primary action pressed when this was connected?
   bool selectionStarted = false;
-  // {} defaults to an identity transform
-  FakeXRRigidTransformInit pointerOrigin;
-  // {} means that there is no gripSpace
   FakeXRRigidTransformInit gripOrigin;
 };
 


### PR DESCRIPTION
After chatting with some other folks it seems like I misunderstood the WebIDL issues. Nested dictionaries _by default_ distinguish between the "field not present" and "dictionary defaults to its default value" case semantically. If you don't want this behavior, you should use `= null` or `= {}` when declaring the dictionary member.


So this should be fine; Gecko and Servo's codegen work with this (https://github.com/servo/servo/pull/23653 for servo, and https://bugzilla.mozilla.org/show_bug.cgi?id=1368949 landed quite a while ago for gecko). It seems like Chrome also can handle this, but i'm not sure.

r? @alcooper91