### PR TITLE
Update Viewport to reflect status as a device property

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -77,13 +77,14 @@ dictionary FakeXRViewInit {
   // https://immersive-web.github.io/webxr/#view-projection-matrix
   required sequence<float> projectionMatrix;
   // https://immersive-web.github.io/webxr/#dom-xrwebgllayer-getviewport
-  required FakeXRViewportInit viewport;
+  required FakeXRDeviceResolution resolution;
   // https://immersive-web.github.io/webxr/#view-offset
   required FakeXRRigidTransformInit viewOffset;
 };
 
+// This represents the native resolution of the device, but may not reflect the viewport exposed to the page.
 // https://immersive-web.github.io/webxr/#xrviewport
-dictionary FakeXRViewportInit {
+dictionary FakeXRDeviceResolution {
     required long width;
     required long height;
 };

--- a/explainer.md
+++ b/explainer.md
@@ -84,8 +84,6 @@ dictionary FakeXRViewInit {
 
 // https://immersive-web.github.io/webxr/#xrviewport
 dictionary FakeXRViewportInit {
-    required long x;
-    required long y;
     required long width;
     required long height;
 };


### PR DESCRIPTION
Ultimately, the viewport that's specified here is the device's native resolution, and doesn't directly correspond to the viewport exposed by xrWebGLLayer.getViewport in the spec:
https://immersive-web.github.io/webxr/#dom-xrwebgllayer-getviewport