### PR TITLE
Change default behavior of unspecified viewerOrigin

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -58,7 +58,8 @@ interface FakeXRDevice {
   Promise<void> disconnect();
 
   // Sets the origin of the viewer
-  void setViewerOrigin(FakeXRRigidTransformInit origin, optional boolean emulatedPosition = false);
+  // If an origin is not specified, then the device is assumed to not be tracking.
+  void setViewerOrigin(optional FakeXRRigidTransformInit origin, optional boolean emulatedPosition = false);
 
   // Simulates devices focusing and blurring sessions.
   void simulateVisibilityChange(XRVisibilityState);

--- a/explainer.md
+++ b/explainer.md
@@ -44,7 +44,8 @@ dictionary FakeXRDeviceInit {
     // Eye level used for calculating floor-level spaces
     float eyeLevel = 1.5;
     // native origin of the viewer
-    // defaults to identity
+    // If not set, the device is currently assumed to not be tracking, and xrFrame.getViewerPose should
+    // not return a pose.
     FakeXRRigidTransformInit viewerOrigin;
 };
 

--- a/explainer.md
+++ b/explainer.md
@@ -58,8 +58,11 @@ interface FakeXRDevice {
   Promise<void> disconnect();
 
   // Sets the origin of the viewer
-  // If an origin is not specified, then the device is assumed to not be tracking.
-  void setViewerOrigin(optional FakeXRRigidTransformInit origin, optional boolean emulatedPosition = false);
+  void setViewerOrigin(FakeXRRigidTransformInit origin, optional boolean emulatedPosition = false);
+
+  // If an origin is not specified, then the device is assumed to not be tracking, emulatedPosition should
+  // be assumed for cases where the UA must always provide a pose.
+  void clearViewerOrigin()
 
   // Simulates devices focusing and blurring sessions.
   void simulateVisibilityChange(XRVisibilityState);


### PR DESCRIPTION
While updating Chromium's implementation it was discovered that always setting the viewerOrigin led to a situation where we could not ensure that xrFrame.getViewerPose returned no pose (see: https://github.com/web-platform-tests/wpt/blob/master/webxr/xrSession_requestAnimationFrame_getViewerPose.https.html), this changes the language such that that test can still be supported.