### PR TITLE
Update names and types for floor level offsets

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -39,7 +39,7 @@ dictionary FakeXRDeviceInit {
     boolean supportsUnbounded = false;
     // The bounds coordinates. If null/empty, bounded reference spaces are not supported. If not, must have at least three elements.
     sequence<FakeXRBoundsPoint> boundsCoodinates;
-    // A transform used to identify the physical position of the user's floor relative to the viewerOrigin.  If not set, indicates that the device cannot identify the physical floor.
+    // A transform used to identify the physical position of the user's floor relative to the viewerOrigin at initialization.  If not set, indicates that the device cannot identify the physical floor.
     FakeXRRigidTransformInit localToFloorLevelTransform;
     // native origin of the viewer
     // If not set, the device is currently assumed to not be tracking, and xrFrame.getViewerPose should
@@ -66,7 +66,7 @@ interface FakeXRDevice {
   void simulateVisibilityChange(XRVisibilityState);
 
   void setBoundsGeometry(sequence<FakeXRBoundsPoint> boundsCoodinates);
-  // Sets the transform from local (typically eye-level) viewerOrigin to the physical floor.
+  // Sets the transform from local (typically eye-level) viewerOrigin at initialization to the physical floor.
   void setLocalToFloorLevelTransform(FakeXRRigidTransformInit localToFloorTransform);
 
   // Indicates that the device can no longer identify the location of the physical floor.

--- a/explainer.md
+++ b/explainer.md
@@ -39,8 +39,8 @@ dictionary FakeXRDeviceInit {
     boolean supportsUnbounded = false;
     // The bounds coordinates. If null/empty, bounded reference spaces are not supported. If not, must have at least three elements.
     sequence<FakeXRBoundsPoint> boundsCoodinates;
-    // Eye level used for calculating floor-level spaces
-    float eyeLevel = 1.5;
+    // A transform used to identify the physical position of the user's floor relative to the viewerOrigin.  If not set, indicates that the device cannot identify the physical floor.
+    FakeXRRigidTransformInit localToFloorLevelTransform;
     // native origin of the viewer
     // If not set, the device is currently assumed to not be tracking, and xrFrame.getViewerPose should
     // not return a pose.
@@ -66,8 +66,11 @@ interface FakeXRDevice {
   void simulateVisibilityChange(XRVisibilityState);
 
   void setBoundsGeometry(sequence<FakeXRBoundsPoint> boundsCoodinates);
-  // Sets eye level used for calculating floor-level spaces
-  void setEyeLevel(float eyeLevel);
+  // Sets the transform from local (typically eye-level) viewerOrigin to the physical floor.
+  void setLocalToFloorLevelTransform(FakeXRRigidTransformInit localToFloorTransform);
+
+  // Indicates that the device can no longer identify the location of the physical floor.
+  void clearLocalToFloorLevelTransform();
 
 
   Promise<FakeXRInputController>


### PR DESCRIPTION
After looking at starting to implement for chromium, the "Eye Level" namespace was a bit of a misnomer, since it's setting the height that should be used to get floor-level spaces.  Additionally, after reading the spec, it seems that we also need to be able to potentially set translation/orientation as well as clear this space, so that (for example) it can be guaranteed that a bounded-floor space rejects and that a local-floor space does not if it is cleared:
https://immersive-web.github.io/webxr/#xrboundedreferencespace-interface

/Fixes #16 