### PR TITLE
Add simulate reset pose back

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -72,6 +72,9 @@ interface FakeXRDevice {
   // Indicates that the device can no longer identify the location of the physical floor.
   void clearLocalToFloorLevelTransform();
 
+  // Used to simulate a major change in tracking and that a reset pose event should be fired
+  // https://immersive-web.github.io/webxr/#event-types
+  void simulateResetPose();
 
   Promise<FakeXRInputController>
       simulateInputSourceConnection(FakeXRInputSourceInit);


### PR DESCRIPTION
A reset event should be triggered when the bounds change or if the origin has shifted as a result of user recalibration or the device changing origins after a major loss of tracking.  While reset events in the first case were supported, no API existed to simulate the latter types of changes.

/Fixes #26