### PR TITLE
Update InputAPI to match webxr spec

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -114,8 +114,8 @@ dictionary FakeXRRigidTransformInit {
 };
 ```
 
-For many UAs input is sent on a per-frame basis, therefore input events are not guaranteed to fire and the FakeXRInputController is not guaranteed
-to be present in session.inputSources until after one animation frame.
+For many UAs input is sent on a per-frame basis, therefore input events are not guaranteed to fire and the FakeXRInputController
+is not guaranteed to be present in session.inputSources until after one animation frame.
 
 ``` WebIDL
 interface FakeXRInputSourceInit {


### PR DESCRIPTION
A few updates to match the spec and discovered during Chrome's updates:
* Adds profiles to the FakeXRInputControllerInit
* Adds setter methods for handedness, targetRayMode, profiles, clicks
* Converts connect/disconnect methods to be synchronous, given that they are not expected to update until the next animation frame has occurred
* Splits setOrigins methods into set/clear methods for both the viewer and pointer to avoid issues with nullable dicts.