### PR TITLE
Clarify usage of FakeXRRigidTransform(Init)

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -101,10 +101,14 @@ dictionary FakeXRDeviceResolution {
 dictionary FakeXRBoundsPoint {
   double x; double z;
 };
+```
 
-// When used as a native origin, it is in the reference space
-// where the viewer's native origin is identity at initialization
-//
+When a FakeXRRigidTransform is used as an origin, it is relative to that object's native origin.
+This object's native origin should be assumed to be identity at it's initialization.
+Any transforms applied to that object (whether via setters or inits), are applied *after* that object's initialization.
+This means that the transform also fundamentally represents the transform from that object in it's reference space to the native space.
+
+```WebIDL
 // https://immersive-web.github.io/webxr/#xrrigidtransform
 dictionary FakeXRRigidTransformInit {
   // must have three elements


### PR DESCRIPTION
Took a stab at trying to further clarify/be explicit about the usage of FakeXRRigidTransform(Init), since there has been some discussions/naming issues that have arisen based on some confusion.

/Fixes #14 
r? @Manishearth 