### PR TITLE
Use XRSystem in the explainer instead of XR

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -9,7 +9,7 @@ fake backend. Because of this, any "synchronous" methods that update the state o
 guaranteed to have that updated state respected until the next "requestAnimationFrame" returns.
 
 ```WebIDL
-partial interface XR {
+partial interface XRSystem {
     [SameObject] readonly attribute XRTest test;
 };
 

--- a/index.bs
+++ b/index.bs
@@ -157,12 +157,12 @@ navigator.xr.test {#xr-test-attribute}
 
 
 <script type="idl">
-partial interface XR {
+partial interface XRSystem {
     [SameObject] readonly attribute XRTest test;
 };
 </script>
 
-The <dfn attribute for="XR">test</dfn> attribute's getter MUST return the {{XRTest}} object that is associated with it. This object MAY be lazily created.
+The <dfn attribute for="XRSystem">test</dfn> attribute's getter MUST return the {{XRTest}} object that is associated with it. This object MAY be lazily created.
 
 
 XRTest {#xrtest-interface}


### PR DESCRIPTION
The XR interface was renamed some time ago to XRSystem. Applied the rename to the partial interface definition in the explainer.