### PR TITLE
Add Lighting Estimation extension

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -51,6 +51,8 @@ spec:WebXR Anchors Module; urlPrefix: https://immersive-web.github.io/anchors/#
     for: XRAnchor;
         type: method; text: delete(); url: dom-xranchor-delete
         type: dfn; text: native origin; url: xranchor-native-origin
+spec:WebXR Lighting Estimation; urlPrefix: https://immersive-web.github.io/lighting-estimation/
+    type:interface; text: XRLightEstimate; url: xrlightestimate-interface
 </pre>
 
 <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
@@ -117,7 +119,7 @@ Introduction {#intro}
 
 <section class="non-normative">
 
-In order to allow <a href="https://web-platform-tests.org/">Web Platform Tests</a> for WebXR there are some basic functions which are common across all tests, such as adding a fake test device and specifying poses. Below is an API which attempts to capture the necessary functions, based off what was defined in the spec. Different browser vendors can implement this API in whatever way is most compatible with their browser. For example, some browsers may back the interface with a WebDriver API while others may use HTTP or IPC mechanisms to communicate with an out of process fake backend. 
+In order to allow <a href="https://web-platform-tests.org/">Web Platform Tests</a> for WebXR there are some basic functions which are common across all tests, such as adding a fake test device and specifying poses. Below is an API which attempts to capture the necessary functions, based off what was defined in the spec. Different browser vendors can implement this API in whatever way is most compatible with their browser. For example, some browsers may back the interface with a WebDriver API while others may use HTTP or IPC mechanisms to communicate with an out of process fake backend.
 
 
 These initialization object and control interfaces do not represent a complete set of WebXR functionality, and are expected to be expanded on as the WebXR spec grows.
@@ -170,7 +172,7 @@ Every [=simulated XR input source=] has a <dfn for="simulated XR input source">p
 
 Every [=simulated XR input source=] has a <dfn for="simulated XR input source">buttonState</dfn> array which is an array of {{FakeXRButtonStateInit}}s. If a {{FakeXRButtonType/"grip"}} button is specified, it SHOULD drive the [=/primary squeeze action=]. If a UA implements the <a href="https://immersive-web.github.io/webxr-gamepads-module/">WebXR Gamepads Module</a> [=buttonState=] SHOULD be used to set the state for the corresponding [=/XR input source|XR input source's=] {{XRInputSource/gamepad}} object, which SHOULD be of type {{GamepadMappingType/"xr-standard"}} if enough buttons are specified to support it.
 
-Every [=simulated XR input source=] has a <dfn for="simulated XR input source">connectionState</dfn> which is a boolean that is initially <code>true</code> and indicates whether the associated [=/XR input source=] should appear in {{XRSession/inputSources}}. When it is changed the associated changes must be reflected on the XRSession, including triggering the {{XRSession/inputsourceschange}} event if necessary by the [=next animation frame=]. 
+Every [=simulated XR input source=] has a <dfn for="simulated XR input source">connectionState</dfn> which is a boolean that is initially <code>true</code> and indicates whether the associated [=/XR input source=] should appear in {{XRSession/inputSources}}. When it is changed the associated changes must be reflected on the XRSession, including triggering the {{XRSession/inputsourceschange}} event if necessary by the [=next animation frame=].
 
 Every [=simulated XR input source=] has a <dfn for="simulated XR input source">primaryActionStarted</dfn> which is a boolean, initially set to <code>false</code>, that indicates whether or not the primary action of the XR input source has been started.
 
@@ -411,7 +413,7 @@ The <dfn method for=FakeXRDevice>setViews(|views|)</dfn> method performs the fol
 When <dfn method for=FakeXRDevice>disconnect()</dfn> method is called, perform the following steps:
 
 
-    1. Remove [=FakeXRDevice/device=] from the [=context object=]'s {{XR}} object's [=list of immersive XR devices=] as if it were disconnected. 
+    1. Remove [=FakeXRDevice/device=] from the [=context object=]'s {{XR}} object's [=list of immersive XR devices=] as if it were disconnected.
     1. If the [=inline XR device=] is equal to the {{FakeXRDevice}}, reset it to the default [=inline XR device=].
 
 </div>
@@ -766,3 +768,34 @@ The {{FakeXRAnchorController/stopTracking()}} method can be used by the tests to
 
 The {{FakeXRAnchorController/setAnchorOrigin(anchorOrigin)}} method can be used to set the controller's [=FakeXRAnchorController/anchor origin=]. Tests can use this method to simulate updates in anchor pose.
 
+Lighting estimation extensions {#lighting-estimation-extensions}
+==================
+
+The lighting estimation extensions for test API SHOULD be implemented by all user agents that implement <a href="https://immersive-web.github.io/lighting-estimation/">WebXR Lighting Estimation</a>.
+
+<script type="idl">
+
+dictionary FakeXRLightEstimateInit {
+  required sequence<float> sphericalHarmonicsCoefficients;
+  DOMPointInit primaryLightDirection;
+  DOMPointInit primaryLightEstimate;
+};
+
+partial interface FakeXRDevice {
+  void setLightEstimate(FakeXRLightEstimateInit init);
+};
+
+</script>
+
+The {{FakeXRDevice}} is extended with internal <dfn for=FakeXRDevice>light estimate</dfn> which is a {{FakeXRLightEstimateInit}}, used to supply data for any requested {{XRLightEstimate}}.
+
+<div class="algorithm" data-algorithm="set-light-estimate">
+When the <dfn method for="FakeXRDevice">setLightEstimate(|init|)</dfn> method is invoked on {{FakeXRDevice}} |device|, run the following steps:
+
+  1. Let |c| be |init|'s {{FakeXRLightEstimateInit/sphericalHarmonicsCoefficients}}.
+  1. If |c| does not have 27 elements, throw a {{TypeError}} and abort these steps.
+  1. Let |d| be |init|'s {{FakeXRLightEstimateInit/primaryLightDirection}}.
+  1. If |d| is set and d's {{DOMPointInit/w}} value does not equal <code>0</code>, throw a {{TypeError}} and abort these steps.
+  1. Set |device|'s [=FakeXRDevice/light estimate=] to |init| by the [=next animation frame=].
+
+</div>

--- a/index.bs
+++ b/index.bs
@@ -778,7 +778,7 @@ The lighting estimation extensions for test API SHOULD be implemented by all use
 dictionary FakeXRLightEstimateInit {
   required sequence<float> sphericalHarmonicsCoefficients;
   DOMPointInit primaryLightDirection;
-  DOMPointInit primaryLightEstimate;
+  DOMPointInit primaryLightIntensity;
 };
 
 partial interface FakeXRDevice {
@@ -795,7 +795,9 @@ When the <dfn method for="FakeXRDevice">setLightEstimate(|init|)</dfn> method is
   1. Let |c| be |init|'s {{FakeXRLightEstimateInit/sphericalHarmonicsCoefficients}}.
   1. If |c| does not have 27 elements, throw a {{TypeError}} and abort these steps.
   1. Let |d| be |init|'s {{FakeXRLightEstimateInit/primaryLightDirection}}.
-  1. If |d| is set and d's {{DOMPointInit/w}} value does not equal <code>0</code>, throw a {{TypeError}} and abort these steps.
+  1. If |d| is set and |d|'s {{DOMPointInit/w}} value does not equal <code>0</code>, throw a {{TypeError}} and abort these steps.
+  1. Let |i| be |init|'s {{FakeXRLightEstimateInit/primaryLightIntensity}}.
+  1. If |i| is set and |i|'s {{DOMPointInit/w}} value does not equal <code>1</code>, throw a {{TypeError}} and abort these steps.
   1. Set |device|'s [=FakeXRDevice/light estimate=] to |init| by the [=next animation frame=].
 
 </div>


### PR DESCRIPTION
Adds extension methods to allow supplying a Fake XRLightingEstimate, along with some simple validation of the type. The type directly translates over to the XRLightingEstimate when requested by the test.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 8, 2021, 11:59 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fimmersive-web%2Fwebxr-test-api%2F4de96d3107323b5afe1c00d19e1ba4eba1ecea47%2Findex.bs&force=1&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20immersive-web/webxr-test-api%2373.)._
</details>
