### PR TITLE
Add secondary views to FakeXRDevice

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -39,7 +39,8 @@ dictionary FakeXRDeviceInit {
     required boolean supportsImmersive;
     // Sequence of modes that should be supported by this device.
     sequence<XRSessionMode> supportedModes;
-    required sequence<FakeXRViewInit> views;
+    required sequence<FakeXRViewInit> primaryViews;
+    required sequence<FakeXRViewInit> secondaryViews;
 
     // https://immersive-web.github.io/webxr/#feature-name
     // The list of feature names that this device supports.
@@ -70,7 +71,7 @@ dictionary FakeXRDeviceInit {
 interface FakeXRDevice {
   // Sets the values to be used for subsequent
   // requestAnimationFrame() callbacks.
-  void setViews(sequence<FakeXRViewInit> views);
+  void setViews(sequence<FakeXRViewInit> primaryViews, sequence<FakeXRViewInit> secondaryViews);
 
   // behaves as if device was disconnected
   Promise<void> disconnect();

--- a/index.bs
+++ b/index.bs
@@ -218,10 +218,14 @@ When this method is invoked, the user agent MUST run the following steps:
   1. Let |promise| be [=a new Promise=].
   1. Run the following steps [=in parallel=]:
     1. Let |device| be a new [=simulated XR device=].
-    1. For each |view| in |init|'s {{FakeXRDeviceInit/views}}:
-        1. Let |v| be the result of running [=parse a view=] on |view|.
+    1. For each |primaryView| in |init|'s {{FakeXRDeviceInit/primaryViews}}:
+        1. Let |p| be the result of running [=parse a view=] on |primaryView|.
         1. If running [=parse a view=] threw an error, reject |promise| with this error and abort these steps.
-        1. [=list/Append=] |v| to |device|'s list of views.
+        1. [=list/Append=] |p| to |device|'s list of primary views.
+    1. For each |secondaryView| in |init|'s {{FakeXRDeviceInit/secondaryViews}}:
+        1. Let |s| be the result of running [=parse a view=] on |secondaryView|.
+        1. If running [=parse a view=] threw an error, reject |promise| with this error and abort these steps.
+        1. [=list/Append=] |s| to |device|'s list of secondary views.
     1. If |init|'s {{FakeXRDeviceInit/boundsCoordinates}} is set, perform the following steps:
         1. If |init|'s {{FakeXRDeviceInit/boundsCoordinates}} has less than 3 elements, reject |promise| with {{TypeError}} and abort these steps.
         1. Set |device|'s [=simulated XR device/native bounds geometry=] to |init|'s {{FakeXRDeviceInit/boundsCoordinates}}.
@@ -270,7 +274,8 @@ FakeXRDeviceInit {#fakexrdeviceinit-dict}
 dictionary FakeXRDeviceInit {
     required boolean supportsImmersive;
     sequence<XRSessionMode> supportedModes;
-    required sequence<FakeXRViewInit> views;
+    required sequence<FakeXRViewInit> primaryViews;
+    required sequence<FakeXRViewInit> secondaryViews;
 
     sequence<any> supportedFeatures;
     sequence<FakeXRBoundsPoint> boundsCoordinates;
@@ -361,7 +366,7 @@ FakeXRDevice {#fakexrdevice-interface}
 
 <script type="idl">
 interface FakeXRDevice : EventTarget {
-  void setViews(sequence<FakeXRViewInit> views);
+  void setViews(sequence<FakeXRViewInit> primaryViews, sequence<FakeXRViewInit> secondaryViews);
 
   Promise<void> disconnect();
 
@@ -407,15 +412,23 @@ To determine when this frame is, for a given operation, choose a frame based on 
 NOTE: The reason we defer an extra frame when there are pending animation frame callbacks is to avoid having to deal with potential race conditions when the device is ready to trigger an animation frame callback, but has not yet. In practice, this means that tests should be written so that they wait until they have performed all such operations <i>before</i> calling the next {{XRSession/requestAnimationFrame()}}, and in case they are running outside of an [=XR animation frame=], should always wait two frames before expecting any updates to take effect.
 </div>
 
+<div class="algorithm" data-algorithm="parse-views-list">
+To <dfn>parse a list of views</dfn> on a [=list=] |views| run the following steps:
+    1. Let |l| be an empty [=list=]
+    1. For each |view| in |views|:
+        1. Let |v| be the result of running [=parse a view=] on |view|.
+        1. [=list/Append=] |v| to |l|.
+    1. Return |l|.
+</div>
+
 <div class="algorithm" data-algorithm="set-views">
-The <dfn method for=FakeXRDevice>setViews(|views|)</dfn> method performs the following steps:
+The <dfn method for=FakeXRDevice>setViews(|primaryViews|, |secondaryViews|)</dfn> method performs the following steps:
 
     1. On the [=next animation frame=], run the following steps:
-        1. Let |l| be an empty [=list=].
-        1. For each |view| in |views|:
-            1. Let |v| be the result of running [=parse a view=] on |view|.
-            1. [=list/Append=] |v| to |l|.
-        1. Set [=FakeXRDevice/device=]'s list of views to |l|.
+        1. Let |p| be the result of running [=parse a list of views=] on |primaryViews|.
+        1. Set [=FakeXRDevice/device=]'s list of primary views to |p|.
+        1. Let |s| be the result of running [=parse a list of views=] on |secondaryViews|.
+        1. Set [=FakeXRDevice/device=]'s list of secondary views to |s|.
 
 </div>
 


### PR DESCRIPTION
To distinguish between primary views and secondary views, the FakeXRDevice and FakeXRDeviceInit should have separate lists of each.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/patrto/webxr-test-api/pull/75.html" title="Last updated on Jan 5, 2022, 9:17 PM UTC (65aa823)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-test-api/75/52f6f2b...patrto:65aa823.html" title="Last updated on Jan 5, 2022, 9:17 PM UTC (65aa823)">Diff</a>