### PR TITLE
Mark secondaryViews for setViews as optional in IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -376,7 +376,7 @@ FakeXRDevice {#fakexrdevice-interface}
 
 <script type="idl">
 interface FakeXRDevice : EventTarget {
-  undefined setViews(sequence<FakeXRViewInit> views, sequence<FakeXRViewInit> secondaryViews);
+  undefined setViews(sequence<FakeXRViewInit> views, optional sequence<FakeXRViewInit> secondaryViews);
 
   Promise<undefined> disconnect();
 


### PR DESCRIPTION
The steps in the spec include a check for whether secondaryViews is set, so that should be reflected in the IDL as well.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/msub2/webxr-test-api/pull/84.html" title="Last updated on Aug 31, 2024, 7:22 AM UTC (dcb656c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-test-api/84/f259b36...msub2:dcb656c.html" title="Last updated on Aug 31, 2024, 7:22 AM UTC (dcb656c)">Diff</a>