### PR TITLE
added [Exposed=Window] to Interface defs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -237,7 +237,7 @@ XRTest {#xrtest-interface}
 The {{XRTest}} object is the entry point for all testing.
 
 <script type="idl">
-[Exposed=Window] interface XRTest {
+[SecureContext, Exposed=Window] interface XRTest {
   Promise<FakeXRDevice> simulateDeviceConnection(FakeXRDeviceInit init);
   undefined simulateUserActivation(Function f);
   Promise<undefined> disconnectAllDevices();
@@ -416,7 +416,7 @@ FakeXRDevice {#fakexrdevice-interface}
 ------------
 
 <script type="idl">
-[Exposed=Window] interface FakeXRDevice : EventTarget {
+[SecureContext, Exposed=Window] interface FakeXRDevice : EventTarget {
   undefined setViews(sequence<FakeXRViewInit> views, optional sequence<FakeXRViewInit> secondaryViews);
 
   Promise<undefined> disconnect();
@@ -566,7 +566,7 @@ dictionary FakeXRInputSourceInit {
   FakeXRRigidTransformInit gripOrigin;
 };
 
-[Exposed=Window] interface FakeXRInputController {
+[SecureContext, Exposed=Window] interface FakeXRInputController {
   undefined setHandedness(XRHandedness handedness);
   undefined setTargetRayMode(XRTargetRayMode targetRayMode);
   undefined setProfiles(sequence<DOMString> profiles);
@@ -834,7 +834,7 @@ The {{FakeXRAnchorCreationParameters/isAttachedToEntity}} attribute will be set 
 The <dfn for=FakeXRAnchorCreationCallback>anchorController</dfn> parameter passed in to {{FakeXRAnchorCreationCallback}} can be used to update the state of the anchor, assuming that the creation request was deemed successful. Tests SHOULD store it and issue commands to it for the entire duration of controlled anchor's lifetime.
 
 <script type="idl">
-[Exposed=Window] interface FakeXRAnchorController {
+[SecureContext, Exposed=Window] interface FakeXRAnchorController {
   readonly attribute boolean deleted;
 
   // Controlling anchor state:

--- a/index.bs
+++ b/index.bs
@@ -237,7 +237,7 @@ XRTest {#xrtest-interface}
 The {{XRTest}} object is the entry point for all testing.
 
 <script type="idl">
-interface XRTest {
+[Exposed=Window] interface XRTest {
   Promise<FakeXRDevice> simulateDeviceConnection(FakeXRDeviceInit init);
   undefined simulateUserActivation(Function f);
   Promise<undefined> disconnectAllDevices();
@@ -416,7 +416,7 @@ FakeXRDevice {#fakexrdevice-interface}
 ------------
 
 <script type="idl">
-interface FakeXRDevice : EventTarget {
+[Exposed=Window] interface FakeXRDevice : EventTarget {
   undefined setViews(sequence<FakeXRViewInit> views, optional sequence<FakeXRViewInit> secondaryViews);
 
   Promise<undefined> disconnect();
@@ -566,7 +566,7 @@ dictionary FakeXRInputSourceInit {
   FakeXRRigidTransformInit gripOrigin;
 };
 
-interface FakeXRInputController {
+[Exposed=Window] interface FakeXRInputController {
   undefined setHandedness(XRHandedness handedness);
   undefined setTargetRayMode(XRTargetRayMode targetRayMode);
   undefined setProfiles(sequence<DOMString> profiles);
@@ -834,7 +834,7 @@ The {{FakeXRAnchorCreationParameters/isAttachedToEntity}} attribute will be set 
 The <dfn for=FakeXRAnchorCreationCallback>anchorController</dfn> parameter passed in to {{FakeXRAnchorCreationCallback}} can be used to update the state of the anchor, assuming that the creation request was deemed successful. Tests SHOULD store it and issue commands to it for the entire duration of controlled anchor's lifetime.
 
 <script type="idl">
-interface FakeXRAnchorController {
+[Exposed=Window] interface FakeXRAnchorController {
   readonly attribute boolean deleted;
 
   // Controlling anchor state:


### PR DESCRIPTION
for ghaction webidl validation error, at #100 

- may need `[SecureContext, Exposed=Window]` but not only `[Exposed=Window]`?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-test-api/pull/102.html" title="Last updated on May 8, 2026, 4:14 PM UTC (de61ce1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/immersive-web/webxr-test-api/102/bc60f7d...de61ce1.html" title="Last updated on May 8, 2026, 4:14 PM UTC (de61ce1)">Diff</a>