### PR TITLE
Switch repo type to `cg-report` in `w3c.json`

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
  {
     "group":      87846
 ,   "contacts":   [ "himorin" ]
-,   "repo-type":  "tests"
+,   "repo-type":  "cg-report"
 }


### PR DESCRIPTION
While the repository is certainly related to tests, it is not meant to contain a test suite, but rather to define an API in a spec that would allow to write tests in WPT.

(Context for the suggestion is that I'm currently going through W3C-related repositories to catalog those that mainly contain code)